### PR TITLE
Update to PHPStan 0.12.23.

### DIFF
--- a/phpstan/Dockerfile
+++ b/phpstan/Dockerfile
@@ -5,7 +5,7 @@ FROM ${IMAGE:-nxtlvlsoftware/pmmp}:${TAG}
 USER root
 RUN wget -qO - https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/bin/composer
-RUN wget -qO /usr/bin/phpstan https://github.com/phpstan/phpstan/releases/download/0.12.11/phpstan.phar
+RUN wget -qO /usr/bin/phpstan https://github.com/phpstan/phpstan/releases/download/0.12.23/phpstan.phar
 RUN chmod o+x /usr/bin/phpstan
 ADD analyze.php /usr/bin/analyze
 ADD phpstan.neon /pocketmine/phpstan.neon


### PR DESCRIPTION
One of the versions between 0.12.11 - 0.12.23 adds support for stub files & inline code error ignoring which wasn't previously present.